### PR TITLE
fix: 🐛 filter out diagnostics from files outside workspace

### DIFF
--- a/src/checks/typescript.spec.ts
+++ b/src/checks/typescript.spec.ts
@@ -346,6 +346,55 @@ describe("runTypescriptCheck", () => {
     expect(result.items[0]).toMatch(/^src\/file\.ts:/);
     expect(result.items[0]).toContain("error inside");
   });
+
+  it("should not include files from sibling directories with similar names", async () => {
+    const mockFileInside = {
+      fileName: "/test/project/src/file.ts",
+      getLineAndCharacterOfPosition: vi.fn().mockReturnValue({
+        character: 0,
+        line: 0,
+      }),
+    };
+
+    const mockFileSibling = {
+      fileName: "/test/project-other/src/file.ts",
+      getLineAndCharacterOfPosition: vi.fn().mockReturnValue({
+        character: 0,
+        line: 0,
+      }),
+    };
+
+    mockFindConfigFile.mockReturnValue("/test/project/tsconfig.json");
+    mockReadConfigFile.mockReturnValue({ config: {} });
+    mockParseJsonConfigFileContent.mockReturnValue({
+      fileNames: [],
+      options: {},
+    });
+    mockCreateProgram.mockReturnValue({});
+    mockGetPreEmitDiagnostics.mockReturnValue([
+      {
+        code: 2304,
+        file: mockFileInside,
+        messageText: "error inside",
+        start: 0,
+      },
+      {
+        code: 2322,
+        file: mockFileSibling,
+        messageText: "error in sibling",
+        start: 0,
+      },
+    ]);
+
+    mockFlattenDiagnosticMessageText.mockReset();
+    mockFlattenDiagnosticMessageText.mockReturnValue("error inside");
+
+    const result = await runTypescriptCheck({ tsconfig: "tsconfig.json" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatch(/^src\/file\.ts:/);
+    expect(result.items[0]).toContain("error inside");
+  });
 });
 
 describe("validateTypescriptDeps", () => {

--- a/src/checks/typescript.ts
+++ b/src/checks/typescript.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 
 import type { TypeScriptCheckConfig } from "@/types";
 
@@ -87,7 +87,9 @@ export async function runTypescriptCheck(config: TypeScriptCheckConfig) {
     const filePath = resolve(diagnostic.file.fileName);
     const workspaceRoot = resolve(cwd);
 
-    return filePath.startsWith(workspaceRoot);
+    return (
+      filePath === workspaceRoot || filePath.startsWith(workspaceRoot + sep)
+    );
   });
 
   const items: string[] = [];


### PR DESCRIPTION
🏁 Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TypeScript diagnostic reporting now filters results to include only issues from files inside the current workspace, excluding external/outside-workspace paths while preserving global (non-file) diagnostics.

* **Tests**
  * Added tests to verify diagnostics are filtered correctly: one ensures outside-workspace diagnostics are excluded, another ensures similarly named sibling-directory files are not included.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->