### PR TITLE
fix: 🐛 just dim all duration to avoid misleading colors

### DIFF
--- a/src/utils/duration.spec.ts
+++ b/src/utils/duration.spec.ts
@@ -48,23 +48,13 @@ describe("formatDuration", () => {
     expect(formatDuration(50.5)).toContain("51");
   });
 
-  it("should apply dim color for sub-millisecond durations", () => {
+  it("should apply dim color to all durations", () => {
     // eslint-disable-next-line no-control-regex -- testing for color codes
-    expect(formatDuration(0)).toMatch(/\u001B\[2m/);
-  });
+    const dimCode = /\u001B\[2m/;
 
-  it("should apply bright green color for fast durations (<100ms)", () => {
-    // eslint-disable-next-line no-control-regex -- testing for color codes
-    expect(formatDuration(50)).toMatch(/\u001B\[32m/);
-  });
-
-  it("should apply yellow color for medium durations (100-999ms)", () => {
-    // eslint-disable-next-line no-control-regex -- testing for color codes
-    expect(formatDuration(500)).toMatch(/\u001B\[33m/);
-  });
-
-  it("should apply red color for slow durations (1000ms+)", () => {
-    // eslint-disable-next-line no-control-regex -- testing for color codes
-    expect(formatDuration(5000)).toMatch(/\u001B\[31m/);
+    expect(formatDuration(0)).toMatch(dimCode);
+    expect(formatDuration(50)).toMatch(dimCode);
+    expect(formatDuration(500)).toMatch(dimCode);
+    expect(formatDuration(5000)).toMatch(dimCode);
   });
 });

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -1,4 +1,4 @@
-import * as c from "./colors";
+import { dim } from "./colors";
 
 function formatMs(ms: number) {
   if (ms < 1000) return `${ms}ms`;
@@ -24,18 +24,8 @@ export function formatDuration(duration: number) {
   const rounded = Math.round(duration);
 
   if (rounded < 1) {
-    return c.dim("<1ms");
+    return dim("<1ms");
   }
 
-  const formatted = formatMs(rounded);
-
-  if (rounded < 100) {
-    return c.green(formatted);
-  }
-
-  if (rounded < 1000) {
-    return c.yellow(formatted);
-  }
-
-  return c.red(formatted);
+  return dim(formatMs(rounded));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Duration times now display with consistent, uniform coloring instead of performance-based color variation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->