### PR TITLE
fix: 🐛 more human language in output

### DIFF
--- a/src/output.spec.ts
+++ b/src/output.spec.ts
@@ -284,7 +284,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        Initial baseline created with 3 issue(s)
+        Initial baseline created with 3 issues
            error1
            error2
            error3
@@ -328,7 +328,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        Initial baseline created with 0 issue(s)
+        Initial baseline created with 0 issues
           Issues  0
 
       Summary
@@ -366,7 +366,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        Initial baseline created with 15 issue(s)
+        Initial baseline created with 15 issues
            error0
            error1
            error2
@@ -415,7 +415,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        2 new issue(s) (regressions):
+        2 new issues (regressions):
            error1
            error2
         Duration  1.5s
@@ -456,7 +456,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        2 issue(s) fixed (improvements):
+        2 issues fixed (improvements):
            error1
            error2
         Duration  1.2s
@@ -497,9 +497,9 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        1 new issue(s) (regressions):
+        1 new issue (regression):
            error3
-        1 issue(s) fixed (improvements):
+        1 issue fixed (improvement):
            error1
         Duration  1.8s
           Issues  2
@@ -538,7 +538,7 @@ describe("formatTextOutput", () => {
     const output = stripAnsi(formatTextOutput(result));
 
     expect(output).toMatchInlineSnapshot(`
-      "eslint (1 issue) 1.5s
+      "eslint (1) 1.5s
 
       Summary
         Improvements  0
@@ -573,7 +573,7 @@ describe("formatTextOutput", () => {
     const output = stripAnsi(formatTextOutput(result));
 
     expect(output).toMatchInlineSnapshot(`
-      "eslint (1 issue)
+      "eslint (1)
 
       Summary
         Improvements  0
@@ -620,9 +620,9 @@ describe("formatTextOutput", () => {
     const output = stripAnsi(formatTextOutput(result));
 
     expect(output).toMatchInlineSnapshot(`
-      "eslint (0 issues) 1s
+      "eslint (0) 1s
 
-      typescript (1 issue) 1.5s
+      typescript (1) 1.5s
 
       Summary
         Improvements  0
@@ -682,7 +682,7 @@ describe("formatTextOutput", () => {
     const output = stripAnsi(formatTextOutput(result));
 
     expect(output).toMatchInlineSnapshot(`
-      "eslint (0 issues) 1.5s
+      "eslint (0) 1.5s
 
       Summary
         Improvements  0
@@ -720,7 +720,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        15 new issue(s) (regressions):
+        15 new issues (regressions):
            error0
            error1
            error2
@@ -769,7 +769,7 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        12 issue(s) fixed (improvements):
+        12 issues fixed (improvements):
            error0
            error1
            error2
@@ -830,13 +830,13 @@ describe("formatTextOutput", () => {
 
     expect(output).toMatchInlineSnapshot(`
       "eslint:
-        1 new issue(s) (regressions):
+        1 new issue (regression):
            error1
         Duration  1s
           Issues  1
 
       typescript:
-        1 issue(s) fixed (improvements):
+        1 issue fixed (improvement):
            error2
         Duration  1.5s
           Issues  0
@@ -921,7 +921,7 @@ describe("formatTextOutput", () => {
     };
     const output = stripAnsi(formatTextOutput(result));
 
-    expect(output).toMatch(/^eslint \(0 issues\)/);
+    expect(output).toMatch(/^eslint \(0\)/);
   });
 
   it("should format multiple initial baselines with newline between them", () => {

--- a/src/utils/colors.spec.ts
+++ b/src/utils/colors.spec.ts
@@ -3,11 +3,18 @@ import * as c from "./colors";
 describe("colors", () => {
   it("should return colorized text", () => {
     expect(c.blue("test")).toBe(`[34mtest[39m`);
+    expect(c.blue(1234)).toBe(`[34m1234[39m`);
     expect(c.bold("test")).toBe(`[1mtest[22m`);
+    expect(c.bold(1234)).toBe(`[1m1234[22m`);
     expect(c.cyan("test")).toBe(`[36mtest[39m`);
+    expect(c.cyan(1234)).toBe(`[36m1234[39m`);
     expect(c.dim("test")).toBe(`[2mtest[22m`);
+    expect(c.dim(1234)).toBe(`[2m1234[22m`);
     expect(c.green("test")).toBe(`[32mtest[39m`);
+    expect(c.green(1234)).toBe(`[32m1234[39m`);
     expect(c.red("test")).toBe(`[31mtest[39m`);
+    expect(c.red(1234)).toBe(`[31m1234[39m`);
     expect(c.yellow("test")).toBe(`[33mtest[39m`);
+    expect(c.yellow(1234)).toBe(`[33m1234[39m`);
   });
 });

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,42 +1,28 @@
 import { styleText } from "node:util";
 
-/**
- * Simple color abstraction over Node.js's styleText
- * Provides a picocolors-like API for the colors we actually use
- */
-
-export const blue = (text: string) => {
-  return styleText("blue", text);
+const createColor = (format: Parameters<typeof styleText>[0]) => {
+  return (value: number | string) => {
+    return styleText(
+      format,
+      typeof value === "number" ? value.toString() : value,
+    );
+  };
 };
 
-export const bold = (text: string) => {
-  return styleText("bold", text);
-};
+export const blue = createColor("blue");
 
-export const cyan = (text: string) => {
-  return styleText("cyan", text);
-};
+export const bold = createColor("bold");
 
-export const dim = (text: string) => {
-  return styleText("dim", text);
-};
+export const cyan = createColor("cyan");
 
-export const green = (text: string) => {
-  return styleText("green", text);
-};
+export const dim = createColor("dim");
 
-export const red = (text: string) => {
-  return styleText("red", text);
-};
+export const green = createColor("green");
 
-export const bgRed = (text: string) => {
-  return styleText("bgRed", text);
-};
+export const red = createColor("red");
 
-export const yellow = (text: string) => {
-  return styleText("yellow", text);
-};
+export const bgRed = createColor("bgRed");
 
-export const black = (text: string) => {
-  return styleText("black", text);
-};
+export const yellow = createColor("yellow");
+
+export const black = createColor("black");

--- a/src/utils/duration.spec.ts
+++ b/src/utils/duration.spec.ts
@@ -1,60 +1,50 @@
-import { formatDuration } from "./duration";
+import { duration } from "./duration";
 
-describe("formatDuration", () => {
+describe("duration", () => {
   it("should format sub-millisecond durations as <1ms", () => {
-    expect(formatDuration(0)).toContain("<1ms");
-    expect(formatDuration(0.4)).toContain("<1ms");
+    expect(duration(0)).toContain("<1ms");
+    expect(duration(0.4)).toContain("<1ms");
   });
 
   it("should format milliseconds correctly", () => {
-    expect(formatDuration(1)).toContain("1ms");
-    expect(formatDuration(50)).toContain("50ms");
-    expect(formatDuration(999)).toContain("999ms");
+    expect(duration(1)).toContain("1ms");
+    expect(duration(50)).toContain("50ms");
+    expect(duration(999)).toContain("999ms");
   });
 
   it("should format whole seconds without decimal", () => {
-    expect(formatDuration(1000)).toContain("1s");
-    expect(formatDuration(5000)).toContain("5s");
-    expect(formatDuration(30_000)).toContain("30s");
+    expect(duration(1000)).toContain("1s");
+    expect(duration(5000)).toContain("5s");
+    expect(duration(30_000)).toContain("30s");
   });
 
   it("should format fractional seconds with decimal", () => {
-    expect(formatDuration(1500)).toContain("1.5s");
-    expect(formatDuration(2300)).toContain("2.3s");
+    expect(duration(1500)).toContain("1.5s");
+    expect(duration(2300)).toContain("2.3s");
   });
 
   it("should format whole minutes without decimal", () => {
-    expect(formatDuration(60_000)).toContain("1m");
-    expect(formatDuration(120_000)).toContain("2m");
+    expect(duration(60_000)).toContain("1m");
+    expect(duration(120_000)).toContain("2m");
   });
 
   it("should format fractional minutes with decimal", () => {
-    expect(formatDuration(90_000)).toContain("1.5m");
-    expect(formatDuration(150_000)).toContain("2.5m");
+    expect(duration(90_000)).toContain("1.5m");
+    expect(duration(150_000)).toContain("2.5m");
   });
 
   it("should format whole hours without decimal", () => {
-    expect(formatDuration(3_600_000)).toContain("1h");
-    expect(formatDuration(7_200_000)).toContain("2h");
+    expect(duration(3_600_000)).toContain("1h");
+    expect(duration(7_200_000)).toContain("2h");
   });
 
   it("should format fractional hours with decimal", () => {
-    expect(formatDuration(5_400_000)).toContain("1.5h");
-    expect(formatDuration(9_000_000)).toContain("2.5h");
+    expect(duration(5_400_000)).toContain("1.5h");
+    expect(duration(9_000_000)).toContain("2.5h");
   });
 
   it("should round fractional milliseconds", () => {
-    expect(formatDuration(42.7)).toContain("43");
-    expect(formatDuration(50.5)).toContain("51");
-  });
-
-  it("should apply dim color to all durations", () => {
-    // eslint-disable-next-line no-control-regex -- testing for color codes
-    const dimCode = /\u001B\[2m/;
-
-    expect(formatDuration(0)).toMatch(dimCode);
-    expect(formatDuration(50)).toMatch(dimCode);
-    expect(formatDuration(500)).toMatch(dimCode);
-    expect(formatDuration(5000)).toMatch(dimCode);
+    expect(duration(42.7)).toContain("43");
+    expect(duration(50.5)).toContain("51");
   });
 });

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -20,7 +20,7 @@ function formatMs(ms: number) {
   return hours % 1 === 0 ? `${hours}h` : `${hours.toFixed(1)}h`;
 }
 
-export function formatDuration(duration: number) {
+export function duration(duration: number) {
   const rounded = Math.round(duration);
 
   if (rounded < 1) {

--- a/src/utils/text.spec.ts
+++ b/src/utils/text.spec.ts
@@ -1,0 +1,15 @@
+import { plural } from "./text";
+
+describe("plural", () => {
+  it("should return singular form for count of 1", () => {
+    expect(plural(1, "issue")).toBe("issue");
+  });
+
+  it("should return plural form for count of 0", () => {
+    expect(plural(0, "issue")).toBe("issues");
+  });
+
+  it("should return plural form for count greater than 1", () => {
+    expect(plural(5, "issue")).toBe("issues");
+  });
+});

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,7 @@
+export function plural(count: number, singular: string) {
+  if (count === 1) {
+    return singular;
+  }
+
+  return `${singular}s`;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected output messages to use proper singular and plural grammar based on item counts (e.g., "1 issue (regression)" vs. "5 regressions").
  * Enhanced visual formatting of issue counts, duration values, regressions, improvements, and summary sections with improved color styling and clearer presentation of metric values for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->