### PR TITLE
Fix lint markdown

### DIFF
--- a/src/reports.spec.ts
+++ b/src/reports.spec.ts
@@ -355,4 +355,37 @@ describe("generateMarkdownReport", () => {
     expect(result).toContain("unix error");
     expect(result).toContain("windows error");
   });
+
+  it("should escape HTML-like syntax in error messages", () => {
+    const baseline = {
+      checks: {
+        typescript: {
+          items: [
+            "/project/src/form.tsx:71 - TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'string | FormikErrors<ItemGroupUploadFormikRow>'.",
+          ],
+          type: "items" as const,
+        },
+      },
+      version: 1,
+    };
+
+    const result = generateMarkdownReport(baseline, "/project/.mejora");
+
+    expect(result).toMatchInlineSnapshot(`
+    "# Mejora Baseline
+
+    ## typescript (1 issue)
+
+
+    ### [src/form.tsx](../src/form.tsx) (1)
+
+    - [Line 71](../src/form.tsx#L71) - TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'string | FormikErrors&lt;ItemGroupUploadFormikRow&gt;'.
+
+    "
+  `);
+
+    expect(result).not.toMatch(/ - .*<[^&]/);
+    expect(result).toContain("&lt;");
+    expect(result).toContain("&gt;");
+  });
 });

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -14,13 +14,17 @@ function parsePathWithLocation(pathWithLocation: string | undefined) {
   return { filePath, line };
 }
 
+function escapeHtml(text: string) {
+  return text.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
 function generateItemLine(item: string, href: string, displayPath: string) {
   const [pathWithLocation, ...rest] = item.split(" - ");
   const { line } = parsePathWithLocation(pathWithLocation);
-
   const linkPath = line ? `${href}#L${line}` : href;
   const lineDisplay = line ? `Line ${line}` : displayPath;
-  const description = rest.length > 0 ? ` - ${rest.join(" - ")}` : "";
+  const description =
+    rest.length > 0 ? ` - ${escapeHtml(rest.join(" - "))}` : "";
 
   return `- [${lineDisplay}](${linkPath})${description}\n`;
 }


### PR DESCRIPTION
closes #29, closes #28, closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML entity escaping in error messages within reports, ensuring proper handling of HTML-like syntax to prevent malformed output.

* **Improvements**
  * Enhanced markdown report formatting with improved spacing and blank lines around sections, headings, and file blocks for better readability.

* **Tests**
  * Added comprehensive test coverage for HTML entity escaping verification in error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->