### PR TITLE
fix: 🐛 md reports should not have line numbers

### DIFF
--- a/src/reports.spec.ts
+++ b/src/reports.spec.ts
@@ -485,4 +485,33 @@ describe("generateMarkdownReport", () => {
     expect(result).toMatch(/[^\n]\n$/);
     expect(result.endsWith("\n\n")).toBe(false);
   });
+
+  it("should handle file paths with line and column numbers", () => {
+    const baseline = {
+      checks: {
+        eslint: {
+          items: [
+            "/project/src/index.ts:4:7 - @typescript-eslint/no-unused-vars",
+          ],
+          type: "items" as const,
+        },
+      },
+      version: 1,
+    };
+    const result = generateMarkdownReport(baseline, "/project/.mejora");
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Mejora Baseline
+
+      ## eslint (1 issue)
+
+      ### [src/index.ts](../src/index.ts) (1)
+
+      - [Line 4](../src/index.ts#L4) - @typescript-eslint/no-unused-vars
+      "
+    `);
+
+    expect(result).not.toContain("src/index.ts:4:7");
+    expect(result).not.toContain("src/index.ts:4");
+  });
 });

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -17,7 +17,7 @@ function escapeHtml(text: string) {
 function parsePathWithLocation(pathWithLocation?: string) {
   if (!pathWithLocation) return { filePath: undefined, line: undefined };
 
-  const match = /^(.+):(\d+)$/.exec(pathWithLocation);
+  const match = /^(.+?):(\d+)(?::\d+)?$/.exec(pathWithLocation);
 
   if (match) {
     return { filePath: match[1], line: match[2] };


### PR DESCRIPTION
🏁 Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing so generated reports correctly handle file paths that include both line and column numbers or extra colon-separated segments; links now point to the correct line and hide raw path-with-location text.

* **Tests**
  * Added a test ensuring reports format paths-with-location into proper links and omit the raw path-with-location string.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->