### PR TITLE
refactor: 🔄 allow `cwd` to be passed to config

### DIFF
--- a/src/core/config.spec.ts
+++ b/src/core/config.spec.ts
@@ -124,5 +124,23 @@ describe("config", () => {
         "No configuration file found.",
       );
     });
+
+    it("should accept an explicit cwd parameter", async () => {
+      writeFileSync(
+        join(testDir, "mejora.config.ts"),
+        `import { defineConfig, eslint } from "${originalCwd}/src/index.ts";
+         export default defineConfig({
+           checks: [
+             eslint({ name: "from-cwd", files: [], rules: {} })
+           ]
+         });`,
+      );
+
+      process.chdir(originalCwd);
+
+      const config = await loadConfig(testDir);
+
+      expect(config.checks[0]?.id).toBe("from-cwd");
+    });
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -68,7 +68,7 @@ export function defineConfig(config: { checks: Check[] }) {
   };
 }
 
-export const loadConfig = async () => {
+export const loadConfig = async (cwd = process.cwd()) => {
   const explorer = lilconfig("mejora", {
     loaders: {
       ".js": loader,
@@ -84,7 +84,7 @@ export const loadConfig = async () => {
     ],
   });
 
-  const result = await explorer.search(process.cwd());
+  const result = await explorer.search(cwd);
 
   if (!result?.config) {
     throw new Error("No configuration file found.");

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -24,20 +24,27 @@ const workerPath = fileURLToPath(new URL("workers/check.mjs", import.meta.url));
  */
 export class Runner {
   private baselineManager: BaselineManager;
+  private cwd: string;
   private registry: CheckRegistry;
 
-  constructor(registry: CheckRegistry, baselinePath?: string) {
+  constructor(
+    registry: CheckRegistry,
+    baselinePath?: string,
+    cwd = process.cwd(),
+  ) {
     this.registry = registry;
     this.baselineManager = new BaselineManager(baselinePath);
+    this.cwd = cwd;
   }
 
   private static async executeChecksParallel(
     checks: Config["checks"],
     baseline: Baseline | null,
+    cwd: string,
   ) {
     try {
       const workerPromises = checks.map(async (check) => {
-        const workerResult = await Runner.executeWorker(check.id);
+        const workerResult = await Runner.executeWorker(check.id, cwd);
 
         const snapshot = normalizeSnapshot(workerResult.snapshot);
         const baselineEntry = BaselineManager.getEntry(baseline, check.id);
@@ -65,10 +72,13 @@ export class Runner {
     }
   }
 
-  private static async executeWorker(checkId: string): Promise<WorkerResult> {
+  private static async executeWorker(
+    checkId: string,
+    cwd: string,
+  ): Promise<WorkerResult> {
     return new Promise((resolve, reject) => {
       const worker = new Worker(workerPath, {
-        workerData: { checkId },
+        workerData: { checkId, cwd },
       });
 
       worker.on("message", resolve);
@@ -125,7 +135,7 @@ export class Runner {
 
     const results =
       checkCount > 1
-        ? await Runner.executeChecksParallel(checksToRun, baseline)
+        ? await Runner.executeChecksParallel(checksToRun, baseline, this.cwd)
         : await this.executeChecksSequential(checksToRun, baseline);
 
     if (!results) {

--- a/src/workers/check.spec.ts
+++ b/src/workers/check.spec.ts
@@ -54,7 +54,7 @@ describe("worker", () => {
   it("should load config on first call", async () => {
     const { checkWorker } = await import("./check");
 
-    await checkWorker({ checkId: "check-1" });
+    await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
 
     expect(loadConfig).toHaveBeenCalledOnce();
   });
@@ -62,23 +62,23 @@ describe("worker", () => {
   it("should throw when check not found", async () => {
     const { checkWorker } = await import("./check");
 
-    await expect(checkWorker({ checkId: "nonexistent" })).rejects.toThrowError(
-      "Check not found in config: nonexistent",
-    );
+    await expect(
+      checkWorker({ checkId: "nonexistent", cwd: "/mock/cwd" }),
+    ).rejects.toThrowError("Check not found in config: nonexistent");
   });
 
   it("should reuse registry for same check type", async () => {
     const { checkWorker } = await import("./check");
 
-    await checkWorker({ checkId: "check-1" });
+    await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
 
     expect(mockInit).toHaveBeenCalledOnce();
 
-    await checkWorker({ checkId: "check-1" });
+    await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
 
     expect(mockInit).toHaveBeenCalledOnce();
 
-    await checkWorker({ checkId: "check-2" });
+    await checkWorker({ checkId: "check-2", cwd: "/mock/cwd" });
 
     expect(mockInit).toHaveBeenCalledTimes(2);
   });
@@ -86,7 +86,7 @@ describe("worker", () => {
   it("should run check and return duration and snapshot", async () => {
     const { checkWorker } = await import("./check");
 
-    const result = await checkWorker({ checkId: "check-1" });
+    const result = await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
 
     expect(result).toMatchObject({
       duration: expect.any(Number),
@@ -98,7 +98,7 @@ describe("worker", () => {
   it("should call runner with check config", async () => {
     const { checkWorker } = await import("./check");
 
-    await checkWorker({ checkId: "check-1" });
+    await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
 
     expect(mockHttpRunner.run).toHaveBeenCalledWith(
       mockConfig.checks[0]?.config,

--- a/src/workers/check.spec.ts
+++ b/src/workers/check.spec.ts
@@ -59,6 +59,14 @@ describe("worker", () => {
     expect(loadConfig).toHaveBeenCalledOnce();
   });
 
+  it("should pass cwd to loadConfig", async () => {
+    const { checkWorker } = await import("./check");
+
+    await checkWorker({ checkId: "check-1", cwd: "/mock/cwd" });
+
+    expect(loadConfig).toHaveBeenCalledWith("/mock/cwd");
+  });
+
   it("should throw when check not found", async () => {
     const { checkWorker } = await import("./check");
 

--- a/src/workers/check.ts
+++ b/src/workers/check.ts
@@ -8,10 +8,16 @@ let configPromise: null | Promise<void> = null;
 
 const registries = new Map<string, CheckRegistry>();
 
-export async function checkWorker({ checkId }: { checkId: string }) {
+export async function checkWorker({
+  checkId,
+  cwd,
+}: {
+  checkId: string;
+  cwd: string;
+}) {
   if (!config) {
     configPromise ??= (async () => {
-      config = await loadConfig();
+      config = await loadConfig(cwd);
     })();
 
     await configPromise;
@@ -51,7 +57,9 @@ export async function checkWorker({ checkId }: { checkId: string }) {
 }
 
 if (parentPort) {
-  const result = await checkWorker(workerData as { checkId: string });
+  const result = await checkWorker(
+    workerData as { checkId: string; cwd: string },
+  );
 
   parentPort.postMessage(result);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for specifying a custom working directory when loading configurations and executing checks — this directory choice is honored across parallel and worker-driven runs.

* **Tests**
  * Added tests covering explicit working-directory handling to ensure config loading and check execution behave correctly when a cwd is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->